### PR TITLE
Håndterer at man kan sende koronaoverføring i ettertid. 

### DIFF
--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
@@ -134,7 +134,8 @@ internal class PdfV1Generator {
                         },
                         "hjelp" to mapOf(
                             "språk" to melding.språk.språkTilTekst(),
-                            "erDet2020Fortsatt" to åretEr2020()
+                            "erDet2020Fortsatt" to åretEr2020(), //TODO Kan fjernes etter nyttår.
+                            "gjelderKoronaoverføringI2020" to melding.gjelderKoronaoverføringI2020()
                         )
                     )
                 )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/melding/MeldingV1.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/melding/MeldingV1.kt
@@ -27,7 +27,11 @@ data class Melding(
     val fordeling: FordelingsMelding? = null,
     val harBekreftetOpplysninger: Boolean,
     val harForståttRettigheterOgPlikter: Boolean
-)
+) {
+    fun gjelderKoronaoverføringI2020(): Boolean {
+        return korona?.stengingsperiode?.tilOgMed?.isBefore(LocalDate.parse("2021-01-01")) ?: false
+    }
+}
 
 data class KoronaOverføringMelding(
     val antallDagerSomSkalOverføres: Int,
@@ -50,7 +54,7 @@ data class OverføringsMelding(
 )
 
 enum class Meldingstype(val type: String) {
-    @JsonAlias("KORONA_OVERFØRE")KORONA("COVID-19"),
+    KORONA("COVID-19"),
     OVERFORING("Overføring"),
     FORDELING("Fordeling")
 }

--- a/src/main/resources/handlebars/soknad.hbs
+++ b/src/main/resources/handlebars/soknad.hbs
@@ -56,10 +56,14 @@
         </ul>
 
         {{#if felles.situasjon.antallDagerBruktIÅr}}
-            {{#if hjelp.erDet2020Fortsatt}}
+            {{#if hjelp.gjelderKoronaoverføringI2020}}
                 <p class="sporsmalstekst">Hvor mange omsorgsdager har du brukt etter 1. juli 2020?</p>
             {{else}}
-                <p class="sporsmalstekst">Hvor mange omsorgsdager har du brukt i år?</p>
+                {{#if hjelp.erDet2020Fortsatt}}
+                    <p class="sporsmalstekst">Hvor mange omsorgsdager har du brukt etter 1. juli 2020?</p>
+                {{else}}
+                    <p class="sporsmalstekst">Hvor mange omsorgsdager har du brukt i år?</p>
+                {{/if}}
             {{/if}}
             <p>{{felles.situasjon.antallDagerBruktIÅr}}</p>
         {{/if}}


### PR DESCRIPTION
Hvis man sender inn koronaoverføring melding i 2021 men det gjelder en periode i 2020, så må vi skrive "Hvor mange omsorgsdager har du brukt etter 1. juli 2020?" i pdf. Ellers gjelder den vanlige sjekken som kan tas bort etter nyttår